### PR TITLE
Add rescue option

### DIFF
--- a/lib/ruboty/gen/cli.rb
+++ b/lib/ruboty/gen/cli.rb
@@ -20,6 +20,7 @@ module Ruboty
       end
 
       desc "gem GEM [OPTIONS]", "Creates a skeleton for creating a ruboty plugin"
+      option :rescue, type: :boolean, desc: 'generate rescue logic'
       def gem(name, *actions)
         actions = [name] if actions.size.zero?
         Bundler::CLI::Gem.new(options, "ruboty-#{name}", self).run

--- a/lib/ruboty/gen/gem.rb
+++ b/lib/ruboty/gen/gem.rb
@@ -42,9 +42,11 @@ module Ruboty
         }
 
         thor.template(File.join('ruboty/handlers/newgem.rb.tt'),       File.join(target, "lib/ruboty/handlers/#{ruboty_plugin_name}.rb"),            opts)
+        action_template = @options['rescue'] ? 'newgem_rescue.rb.tt' : 'newgem.rb.tt'
         actions.each do |action|
           opts[:constant_action] = camelize(action)
-          thor.template(File.join('ruboty/newgem/actions/newgem.rb.tt'), File.join(target, "lib/ruboty/#{ruboty_plugin_name}/actions/#{action}.rb"), opts)
+          opts[:action] = action
+          thor.template(File.join("ruboty/newgem/actions/#{action_template}"), File.join(target, "lib/ruboty/#{ruboty_plugin_name}/actions/#{action}.rb"), opts)
         end
       end
 

--- a/templates/ruboty/newgem/actions/newgem_rescue.rb.tt
+++ b/templates/ruboty/newgem/actions/newgem_rescue.rb.tt
@@ -1,0 +1,19 @@
+module Ruboty
+  module <%= config[:ruboty_plugin_constant_name] %>
+    module Actions
+      class <%= config[:constant_action] %> < Ruboty::Actions::Base
+        def call
+          message.reply(<%= config[:action] %>)
+        end
+
+        private
+
+        def <%= config[:action] %>
+          "TODO: write your logic."
+        rescue => e
+          e.message
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add rescue option to `ruboty-gen gem` command.
## Example

``` bash
$ ruboty-gen gem some_plugin some_action --rescue
```
- generated code

``` ruby
module Ruboty
  module SomePlugin
    module Actions
      class SomeAction < Ruboty::Actions::Base
        def call
          message.reply(some_action)
        end
      end

      def some_action
        "TODO: write your logic."
      rescue => e
        e.message
      end
    end
  end
end
```
