### PR TITLE
no error

### DIFF
--- a/lib/ruboty/gen/cli.rb
+++ b/lib/ruboty/gen/cli.rb
@@ -6,7 +6,6 @@ require 'bundler/cli/gem'
 module Ruboty
   module Gen
     class CLI < Bundler::CLI
-      include Thor::Actions
 
       def self.start(*)
         super


### PR DESCRIPTION
I have to be able to avoid a temporary error because the error has occurred in the ruboty-gen command.

include Thor :: Actions While the has been removed, please delete each this branch If it is different from the intended
